### PR TITLE
Few improvements to ci

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -29,7 +29,7 @@ jobs:
       run: cargo +nightly fmt -- --check
 
     - name: Run clippy
-      run: cargo +nightly clippy -- -W clippy::perf
+      run: cargo +nightly clippy --locked -- -W clippy::perf
 
     - name: Install cargo-udeps
       run: cargo install cargo-udeps --locked
@@ -37,9 +37,9 @@ jobs:
     - name: Run cargo udeps (strict for main)
       run: |
         if [ "${{ github.ref_name }}" = "main" ]; then
-          cargo +nightly udeps --frozen --all-targets
+          cargo +nightly udeps --locked --all-targets
         else
-          cargo +nightly udeps --frozen --all-targets || true
+          cargo +nightly udeps --locked --all-targets || true
         fi
 
   build_and_test:
@@ -55,4 +55,4 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Run tests
-      run: cargo test --frozen --verbose
+      run: cargo test --locked --verbose

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -31,16 +31,11 @@ jobs:
     - name: Run clippy
       run: cargo +nightly clippy --locked -- -W clippy::perf
 
-    - name: Install cargo-udeps
-      run: cargo install cargo-udeps --locked
-
-    - name: Run cargo udeps (strict for main)
+    - name: Install and run cargo-udeps (only if target branch is main)
+      if: ${{ github.event.pull_request.base.ref == 'main' }}
       run: |
-        if [ "${{ github.ref_name }}" = "main" ]; then
-          cargo +nightly udeps --locked --all-targets
-        else
-          cargo +nightly udeps --locked --all-targets || true
-        fi
+        cargo install cargo-udeps --locked
+        cargo +nightly udeps --locked --all-targets
 
   build_and_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -29,7 +29,7 @@ jobs:
       run: cargo +nightly fmt -- --check
 
     - name: Run clippy
-      run: cargo +nightly clippy --frozen -- -W clippy::perf
+      run: cargo +nightly clippy -- -W clippy::perf
 
     - name: Install cargo-udeps
       run: cargo install cargo-udeps --locked

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -29,7 +29,7 @@ jobs:
       run: cargo +nightly fmt -- --check
 
     - name: Run clippy
-      run: cargo +nightly clippy --locked -- -W clippy::perf
+      run: cargo +nightly clippy --locked -- -W clippy::perfi -D warnings
 
     - name: Install and run cargo-udeps (only if target branch is main)
       if: ${{ github.event.pull_request.base.ref == 'main' }}

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -11,7 +11,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,18 +22,39 @@ jobs:
       uses: dtolnay/rust-toolchain@nightly
       with:
         components: rustfmt, clippy
-    
+
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
-
-    - name: Run build
-      run: cargo build --verbose
 
     - name: Run fmt
       run: cargo +nightly fmt -- --check
 
     - name: Run clippy
       run: cargo +nightly clippy -- -W clippy::perf
+
+    - name: Install cargo-udeps
+      run: cargo install cargo-udeps
+
+    - name: Run cargo udeps (strict for main)
+      run: |
+        if [ "${{ github.ref_name }}" = "main" ]; then
+          cargo +nightly udeps --all-targets
+        else
+          cargo +nightly udeps --all-targets || true
+        fi
+
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Rust (nightly)
+      uses: dtolnay/rust-toolchain@nightly
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
 
     - name: Run tests
       run: cargo test --verbose

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -13,7 +13,6 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -30,22 +29,21 @@ jobs:
       run: cargo +nightly fmt -- --check
 
     - name: Run clippy
-      run: cargo +nightly clippy -- -W clippy::perf
+      run: cargo +nightly clippy --frozen -- -W clippy::perf
 
     - name: Install cargo-udeps
-      run: cargo install cargo-udeps
+      run: cargo install cargo-udeps --locked
 
     - name: Run cargo udeps (strict for main)
       run: |
         if [ "${{ github.ref_name }}" = "main" ]; then
-          cargo +nightly udeps --all-targets
+          cargo +nightly udeps --frozen --all-targets
         else
-          cargo +nightly udeps --all-targets || true
+          cargo +nightly udeps --frozen --all-targets || true
         fi
 
   build_and_test:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -57,4 +55,4 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --frozen --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -9253,9 +9253,9 @@ checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,11 +140,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.55"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e39f295f876b61a1222d937e1dd31f965e4a1acc3bba98e448dd7e84b1a4566"
+checksum = "a725039ef382d1b6b4e2ebcb15b1efff6cde9af48c47a1bdce6fb67b9456c34b"
 dependencies = [
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "num_enum 0.7.3",
  "strum",
 ]
@@ -156,7 +156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88e1edea70787c33e11197d3f32ae380f3db19e6e061e539a5bcf8184a6b326"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
@@ -175,7 +175,7 @@ checksum = "57b1bb53f40c0273cd1975573cd457b39213e68584e36d1401d25fd0398a1d65"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rlp",
  "alloy-serde",
  "serde",
@@ -191,11 +191,11 @@ dependencies = [
  "alloy-json-abi",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-types-eth",
- "alloy-sol-types 0.8.18",
+ "alloy-sol-types 0.8.19",
  "alloy-transport",
  "futures",
  "futures-util",
@@ -204,26 +204,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0713007d14d88a6edb8e248cddab783b698dbb954a28b8eee4bab21cfb7e578"
+checksum = "648275bb59110f88cc5fa9a176845e52a554ebfebac2d21220bcda8c9220f797"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-primitives 0.8.18",
- "alloy-sol-types 0.8.18",
+ "alloy-primitives 0.8.19",
+ "alloy-sol-types 0.8.19",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e3b98c37b3218924cd1d2a8570666b89662be54e5b182643855f783ea68b33"
+checksum = "bc9138f4f0912793642d453523c3116bd5d9e11de73b70177aa7cb3e94b98ad2"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-sol-type-parser",
- "alloy-sol-types 0.8.18",
+ "alloy-sol-types 0.8.19",
  "const-hex",
  "itoa",
  "serde",
@@ -237,7 +237,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rlp",
  "serde",
 ]
@@ -248,7 +248,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c986539255fb839d1533c128e190e557e52ff652c9ef62939e233a81dd93f7e"
 dependencies = [
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rlp",
  "derive_more 1.0.0",
  "k256",
@@ -263,7 +263,7 @@ checksum = "5f9fadfe089e9ccc0650473f2d4ef0a28bc015bbca5631d9f0f09e49b557fdb3"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
@@ -275,11 +275,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731ea743b3d843bc657e120fb1d1e9cc94f5dab8107e35a82125a63e6420a102"
+checksum = "24acd2f5ba97c7a320e67217274bc81fe3c3174b8e6144ec875d9d54e760e278"
 dependencies = [
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -291,8 +291,8 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e29040b9d5fe2fb70415531882685b64f8efd08dfbd6cc907120650504821105"
 dependencies = [
- "alloy-primitives 0.8.18",
- "alloy-sol-types 0.8.18",
+ "alloy-primitives 0.8.19",
+ "alloy-sol-types 0.8.19",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -310,12 +310,12 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
- "alloy-sol-types 0.8.18",
+ "alloy-sol-types 0.8.19",
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
@@ -332,7 +332,7 @@ checksum = "9081c099e798b8a2bba2145eb82a9a146f01fc7a35e9ab6e7b43305051f97550"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-serde",
  "serde",
 ]
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788bb18e8f61d5d9340b52143f27771daf7e1dccbaf2741621d2493f9debf52e"
+checksum = "ec878088ec6283ce1e90d280316aadd3d6ce3de06ff63d68953c855e7e447e92"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -399,7 +399,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
@@ -434,7 +434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695809e743628d54510c294ad17a4645bd9f465aeb0d20ee9ce9877c9712dc9c"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-transport",
  "bimap",
  "futures",
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542548a609dca89fcd72b3b9f355928cf844d4363c5eed9c5273a3dd225e097"
+checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a833d97bf8a5f0f878daf2c8451fff7de7f9de38baa5a45d936ec718d81255a"
+checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -475,7 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531137b283547d5b9a5cafc96b006c64ef76810c681d606f28be9781955293b6"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -500,7 +500,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3410a472ce26c457e9780f708ee6bd540b30f88f1f31fdab7a11d00bd6aa1aee"
 dependencies = [
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -526,7 +526,7 @@ checksum = "03bd16fa4959255ebf4a7702df08f325e5631df5cdca07c8a8e58bdc10fe02e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 1.0.0",
@@ -544,10 +544,10 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rlp",
  "alloy-serde",
- "alloy-sol-types 0.8.18",
+ "alloy-sol-types 0.8.19",
  "derive_more 1.0.0",
  "itertools 0.13.0",
  "serde",
@@ -560,7 +560,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5851bf8d5ad33014bd0c45153c603303e730acc8a209450a7ae6b4a12c2789e2"
 dependencies = [
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "serde",
  "serde_json",
 ]
@@ -571,7 +571,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e10ca565da6500cca015ba35ee424d59798f2e1b85bc0dd8f81dafd401f029a"
 dependencies = [
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "async-trait",
  "auto_impl",
  "elliptic-curve",
@@ -587,7 +587,7 @@ checksum = "47fababf5a745133490cde927d48e50267f97d3d1209b9fc9f1d1d666964d172"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-signer",
  "async-trait",
  "k256",
@@ -611,12 +611,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07b74d48661ab2e4b50bb5950d74dbff5e61dd8ed03bb822281b706d54ebacb"
+checksum = "8d039d267aa5cbb7732fa6ce1fd9b5e9e29368f580f80ba9d7a8450c794de4b2"
 dependencies = [
- "alloy-sol-macro-expander 0.8.18",
- "alloy-sol-macro-input 0.8.18",
+ "alloy-sol-macro-expander 0.8.19",
+ "alloy-sol-macro-input 0.8.19",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -643,12 +643,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19cc9c7f20b90f9be1a8f71a3d8e283a43745137b0837b1a1cb13159d37cad72"
+checksum = "620ae5eee30ee7216a38027dec34e0585c55099f827f92f50d11e3d2d3a4a954"
 dependencies = [
  "alloy-json-abi",
- "alloy-sol-macro-input 0.8.18",
+ "alloy-sol-macro-input 0.8.19",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.7.0",
@@ -656,7 +656,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
- "syn-solidity 0.8.18",
+ "syn-solidity 0.8.19",
  "tiny-keccak",
 ]
 
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713b7e6dfe1cb2f55c80fb05fd22ed085a1b4e48217611365ed0ae598a74c6ac"
+checksum = "ad9f7d057e00f8c5994e4ff4492b76532c51ead39353aa2ed63f8c50c0f4d52e"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -689,14 +689,14 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.96",
- "syn-solidity 0.8.18",
+ "syn-solidity 0.8.19",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eda2711ab2e1fb517fc6e2ffa9728c9a232e296d16810810e6957b781a1b8bc"
+checksum = "74e60b084fe1aef8acecda2743ff2d93c18ff3eb67a2d3b12f62582a1e66ef5e"
 dependencies = [
  "serde",
  "winnow 0.6.24",
@@ -716,13 +716,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b478bc9c0c4737a04cd976accde4df7eba0bdc0d90ad6ff43d58bc93cf79c1"
+checksum = "c1382302752cd751efd275f4d6ef65877ddf61e0e6f5ac84ef4302b79a33a31a"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.18",
- "alloy-sol-macro 0.8.18",
+ "alloy-primitives 0.8.19",
+ "alloy-sol-macro 0.8.19",
  "const-hex",
  "serde",
 ]
@@ -805,7 +805,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6917c79e837aa7b77b7a6dae9f89cbe15313ac161c4d3cfaf8909ef21f3d22d8"
 dependencies = [
- "alloy-primitives 0.8.18",
+ "alloy-primitives 0.8.19",
  "alloy-rlp",
  "arrayvec",
  "derive_more 1.0.0",
@@ -1601,7 +1601,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1638,9 +1638,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce58205497760ded0e4c743bc7a7aee28da5ca29b4adb7a635bf3bee2d118ebc"
+checksum = "1f7ecaa1f078d094627e8413f6d5623c3605b40327194f8e6857b6af7da24587"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -2645,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "der"
@@ -3818,7 +3818,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -4868,7 +4868,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
@@ -5060,7 +5060,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -5415,7 +5415,7 @@ version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -6197,7 +6197,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -6417,7 +6417,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -6693,9 +6693,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fb75d62d70320adc7adae2abad354a3b7565603115dfb3134465227846475"
+checksum = "f2d38498a55589122b195aa5024d2c0b02231efdb01c090881b9d535660f97c9"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6708,9 +6708,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99fb40aeeaf59dddd6b6c3a177c95e8b3c7f0fb6de7d25a0687d12398323292"
+checksum = "2b178bec61b5a589feeddcc8f9987119dccfd32f17d98dfedf14921591b35bf4"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6726,10 +6726,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "risc0-circuit-recursion"
-version = "1.2.0"
+name = "risc0-circuit-keccak"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b0736401dd72a60a775e675bd0adba2e0e0e2ce2b73b63fda2899d9d7889b0"
+checksum = "723af53138c76e5c167f52c0396071ebd735a79561732de974dabb545ba2d1be"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "paste",
+ "risc0-binfmt",
+ "risc0-circuit-recursion",
+ "risc0-core",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-recursion"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c7665d06d6dd42bff80dd7690fddecc49b664621336ad0542505e139a470ad"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -6742,9 +6758,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6d7eb9ae600c2df004bf8849db2df870fd56bd5911a2ad756fb8701350b3c6"
+checksum = "53c44a97bf5f90a90a51fcc3667b12592a407431f7bab34dc5e77f097675699d"
 dependencies = [
  "anyhow",
  "metal",
@@ -6758,9 +6774,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733491635d50b742d1f30a923aa3b83d62f35cef724bbf402dfc02e6f10f587a"
+checksum = "09f45bab0bb477240e7d45a25e618603ef4196421728a115b6d4b7a6036535a5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -6768,9 +6784,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5babc69b0db6906a6ff4011641109ca2ba06636096356b32208b0dfb26b3809"
+checksum = "a73e92874649e10cbdd6b3069c4f0f6a7daab1251d18ba8b190ef9f99b39975c"
 dependencies = [
  "anyhow",
  "ark-bn254 0.4.0",
@@ -6789,9 +6805,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eadc5099bf0d8ecaed718810dc5deaf237ae39a2fcb66e542e8f9660132617"
+checksum = "b6f1990995a8933cdd1812dc9d8d0e5f04032a045cc47ef00557996b566e2194"
 dependencies = [
  "anyhow",
  "blake2",
@@ -6813,9 +6829,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b619085d02d57dcafc41eb74714682797ed666621ced1814c55bbe7ae7762ba"
+checksum = "b7dd5caa549aa61f00a69f2b625b0d4e42e40595f3d0b29773c80856baa244fd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6829,6 +6845,7 @@ dependencies = [
  "prost",
  "risc0-binfmt",
  "risc0-build",
+ "risc0-circuit-keccak",
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
@@ -6839,7 +6856,6 @@ dependencies = [
  "semver 1.0.24",
  "serde",
  "sha2",
- "sha3",
  "stability",
  "tempfile",
  "tracing",
@@ -6847,11 +6863,12 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bbcc486222a0086d36244ae1f388cac1318270bca2dd23d77af2005d679edf"
+checksum = "53b825852cf55c5f54f1f21d178055e6959fa5f4e839eab2ad56cfd377d2e7f8"
 dependencies = [
  "bytemuck",
+ "cfg-if",
  "getrandom",
  "libm",
  "stability",
@@ -6916,7 +6933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "serde",
  "serde_derive",
 ]
@@ -7032,7 +7049,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -7306,7 +7323,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -8242,9 +8259,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e89d8bf2768d277f40573c83a02a099e96d96dd3104e13ea676194e61ac4b0"
+checksum = "b84e4d83a0a6704561302b917a932484e1cae2d8c6354c64be8b7bac1c1fe057"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -8310,7 +8327,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "system-configuration-sys 0.6.0",
 ]
@@ -8859,7 +8876,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "bytes",
  "http 1.2.0",
  "http-body 1.0.1",
@@ -9853,7 +9870,7 @@ version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "indexmap 2.7.0",
  "semver 1.0.24",
 ]

--- a/crates/taralli-provider/src/api.rs
+++ b/crates/taralli-provider/src/api.rs
@@ -13,6 +13,9 @@ pub struct ProviderApi {
     server_url: Url,
 }
 
+type StreamResult =
+    Result<Pin<Box<dyn Stream<Item = Result<Request<ProvingSystemParams>>> + Send>>>;
+
 impl ProviderApi {
     pub fn new(config: ApiConfig) -> Self {
         Self {
@@ -20,9 +23,7 @@ impl ProviderApi {
         }
     }
 
-    pub fn subscribe_to_markets(
-        &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Request<ProvingSystemParams>>> + Send>>> {
+    pub fn subscribe_to_markets(&self) -> StreamResult {
         // Attempt to join the URL, log error if it fails
         let url = self
             .server_url

--- a/crates/taralli-provider/src/api.rs
+++ b/crates/taralli-provider/src/api.rs
@@ -13,8 +13,8 @@ pub struct ProviderApi {
     server_url: Url,
 }
 
-type StreamResult =
-    Result<Pin<Box<dyn Stream<Item = Result<Request<ProvingSystemParams>>> + Send>>>;
+// type alias for SSE stream returned by the protocol server
+pub type RequestStream = Pin<Box<dyn Stream<Item = Result<Request<ProvingSystemParams>>> + Send>>;
 
 impl ProviderApi {
     pub fn new(config: ApiConfig) -> Self {
@@ -23,7 +23,7 @@ impl ProviderApi {
         }
     }
 
-    pub fn subscribe_to_markets(&self) -> StreamResult {
+    pub fn subscribe_to_markets(&self) -> Result<RequestStream> {
         // Attempt to join the URL, log error if it fails
         let url = self
             .server_url

--- a/crates/taralli-provider/src/builder.rs
+++ b/crates/taralli-provider/src/builder.rs
@@ -39,15 +39,18 @@ where
 {
     pub fn new(config: ProviderConfig<T, P, N>) -> Self {
         // Initialize with defaults but override shared values
-        let mut bidder_config = BidderConfig::default();
-        bidder_config.market_address = config.market_address;
-
-        let mut resolver_config = ResolverConfig::default();
-        resolver_config.market_address = config.market_address;
-
-        let mut api_config = ApiConfig::default();
-        api_config.server_url = config.server_url.clone();
-
+        let bidder_config = BidderConfig {
+            market_address: config.market_address,
+            ..Default::default()
+        };
+        let resolver_config = ResolverConfig {
+            market_address: config.market_address,
+            ..Default::default()
+        };
+        let api_config = ApiConfig {
+            server_url: config.server_url.clone(),
+            ..Default::default()
+        };
         Self {
             config,
             workers: HashMap::new(),

--- a/crates/taralli-provider/src/workers/aligned_layer.rs
+++ b/crates/taralli-provider/src/workers/aligned_layer.rs
@@ -133,7 +133,7 @@ impl AlignedLayerWorker {
                     GnarkSchemeConfig::PlonkBls12_381 => ProvingSystemId::GnarkPlonkBls12_381,
                 };
                 Ok(VerificationData {
-                    proving_system: proving_system,
+                    proving_system,
                     proof,
                     proof_generator_addr: H160::from_slice(self.prover_address.as_slice()),
                     vm_program_code: None,
@@ -241,7 +241,7 @@ impl AlignedLayerWorker {
                 };
 
                 // run gnark prover
-                let proof_output_path = Self::execute_gnark_prover(&gnark_params).await?;
+                let proof_output_path = Self::execute_gnark_prover(gnark_params).await?;
 
                 // Deserialize proof info from go prover output file
                 let aligned_verification_inputs: AlignedVerificationInputs =
@@ -270,7 +270,7 @@ impl AlignedLayerWorker {
                 // use sp1 compute worker to generate proof
                 let prover_client = ProverClient::local();
                 let sp1_worker = Sp1Worker::new(prover_client);
-                let sp1_proof = sp1_worker.generate_proof(&sp1_params)?;
+                let sp1_proof = sp1_worker.generate_proof(sp1_params)?;
 
                 // serialize proof for aligned layer
                 let serialized_proof = bincode::serialize(&sp1_proof)
@@ -292,7 +292,7 @@ impl AlignedLayerWorker {
                 };
 
                 let risc0_worker = Risc0Worker::new(ProverOpts::succinct());
-                let proof_info = risc0_worker.generate_proof(&risc0_params)?;
+                let proof_info = risc0_worker.generate_proof(risc0_params)?;
                 let serialized_proof = bincode::serialize(&proof_info.receipt.inner)
                     .map_err(|e| ProviderError::WorkerExecutionFailed(e.to_string()))?;
 

--- a/crates/taralli-provider/src/workers/arkworks.rs
+++ b/crates/taralli-provider/src/workers/arkworks.rs
@@ -23,7 +23,7 @@ use taralli_primitives::{taralli_systems::systems::arkworks::ArkworksProofParams
 use tempfile::NamedTempFile;
 use wasmer::Store;
 
-type TripleOf<T> = (Vec<T>, Vec<Vec<T>>, Vec<T>);
+type ProofValues = (Vec<DynSolValue>, Vec<Vec<DynSolValue>>, Vec<DynSolValue>);
 
 #[derive(Default)]
 pub struct ArkworksWorker;
@@ -34,7 +34,7 @@ impl ArkworksWorker {
         Self
     }
 
-    fn proof_to_sol_values(proof: &Proof<Bn254>) -> Result<TripleOf<DynSolValue>> {
+    fn proof_to_sol_values(proof: &Proof<Bn254>) -> Result<ProofValues> {
         fn to_u256<T: std::fmt::Display>(f: T) -> Result<U256> {
             U256::from_str(&f.to_string())
                 .map_err(|e| ProviderError::WorkerExecutionFailed(e.to_string()))

--- a/crates/taralli-provider/src/workers/arkworks.rs
+++ b/crates/taralli-provider/src/workers/arkworks.rs
@@ -23,6 +23,8 @@ use taralli_primitives::{taralli_systems::systems::arkworks::ArkworksProofParams
 use tempfile::NamedTempFile;
 use wasmer::Store;
 
+type TripleOf<T> = (Vec<T>, Vec<Vec<T>>, Vec<T>);
+
 #[derive(Default)]
 pub struct ArkworksWorker;
 
@@ -32,9 +34,7 @@ impl ArkworksWorker {
         Self
     }
 
-    fn proof_to_sol_values(
-        proof: &Proof<Bn254>,
-    ) -> Result<(Vec<DynSolValue>, Vec<Vec<DynSolValue>>, Vec<DynSolValue>)> {
+    fn proof_to_sol_values(proof: &Proof<Bn254>) -> Result<TripleOf<DynSolValue>> {
         fn to_u256<T: std::fmt::Display>(f: T) -> Result<U256> {
             U256::from_str(&f.to_string())
                 .map_err(|e| ProviderError::WorkerExecutionFailed(e.to_string()))

--- a/crates/taralli-provider/src/workers/gnark.rs
+++ b/crates/taralli-provider/src/workers/gnark.rs
@@ -87,7 +87,7 @@ impl GnarkWorker {
 
     async fn generate_proof(&self, gnark_params: &GnarkProofParams) -> Result<(Vec<u8>, Value)> {
         // run gnark prover
-        let proof_output_path = Self::execute_gnark_prover(&gnark_params).await?;
+        let proof_output_path = Self::execute_gnark_prover(gnark_params).await?;
 
         // Read proof from output file
         let proof = std::fs::read(proof_output_path)

--- a/crates/taralli-server/src/app_state.rs
+++ b/crates/taralli-server/src/app_state.rs
@@ -32,6 +32,7 @@ where
     P: Provider<T, Ethereum> + Clone,
     M: Clone,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         rpc_provider: P,
         subscription_manager: Arc<SubscriptionManager<M>>,


### PR DESCRIPTION
- Parallelize build and test
- Ditch separate clippy and build steps, since clippy already makes a build
- Enforce udeps check for prs targeting main
- use `--locked` to enforce the usage of the same versions of deps on `Cargo.lock` 