### PR TITLE
Feat(server): Improvements to how data is ingested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.59"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d37bc62b68c056e3742265ab73c73d413d07357909e0e4ea1e95453066a7469"
+checksum = "3a754dbb534198644cb8355b8c23f4aaecf03670fb9409242be1fa1e25897ee9"
 dependencies = [
  "alloy-primitives",
  "num_enum 0.7.3",
@@ -184,14 +184,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce20c85f6b24a5da40b2350a748e348417f0465dedbb523a4d149143bc4a41ce"
+checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
 dependencies = [
- "alloy-eips 0.11.0",
+ "alloy-eips 0.11.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.11.0",
+ "alloy-serde 0.11.1",
  "alloy-trie",
  "auto_impl",
  "c-kzg",
@@ -215,15 +215,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e23af02ccded0031ef2b70df4fe9965b1c742c5d5384c8c767ae0311f7e62b9"
+checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
 dependencies = [
- "alloy-consensus 0.11.0",
- "alloy-eips 0.11.0",
+ "alloy-consensus 0.11.1",
+ "alloy-eips 0.11.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.11.0",
+ "alloy-serde 0.11.1",
  "serde",
 ]
 
@@ -345,16 +345,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7149e011edbd588f6df6564b369c75f6b538d76db14053d95e0b43b2d92e4266"
+checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702 0.5.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.11.0",
+ "alloy-serde 0.11.1",
  "auto_impl",
  "c-kzg",
  "derive_more",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c5c9651fd20a2fd4a57606b6a570d1c17ab86e686b962b2f1ecac68b51e020"
+checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -430,20 +430,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02ed56783fb2c086a4ac8961175dd6d3ad163e6cf6125f0b83f7de03379b607"
+checksum = "8be03f2ebc00cf88bd06d3c6caf387dceaa9c7e6b268216779fa68a9bf8ab4e6"
 dependencies = [
- "alloy-consensus 0.11.0",
- "alloy-consensus-any 0.11.0",
- "alloy-eips 0.11.0",
- "alloy-json-rpc 0.11.0",
- "alloy-network-primitives 0.11.0",
+ "alloy-consensus 0.11.1",
+ "alloy-consensus-any 0.11.1",
+ "alloy-eips 0.11.1",
+ "alloy-json-rpc 0.11.1",
+ "alloy-network-primitives 0.11.1",
  "alloy-primitives",
- "alloy-rpc-types-any 0.11.0",
- "alloy-rpc-types-eth 0.11.0",
- "alloy-serde 0.11.0",
- "alloy-signer 0.11.0",
+ "alloy-rpc-types-any 0.11.1",
+ "alloy-rpc-types-eth 0.11.1",
+ "alloy-serde 0.11.1",
+ "alloy-signer 0.11.1",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -468,14 +468,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0624cfa9311aa8283cd3bf5eed883d0d1e823e2a4d57b30e1b49af4b3678a6b"
+checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
 dependencies = [
- "alloy-consensus 0.11.0",
- "alloy-eips 0.11.0",
+ "alloy-consensus 0.11.1",
+ "alloy-eips 0.11.1",
  "alloy-primitives",
- "alloy-serde 0.11.0",
+ "alloy-serde 0.11.1",
  "serde",
 ]
 
@@ -640,13 +640,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e119337400d8b0348e1576ab37ffa56d1a04cbc977a84d4fa0a527d7cb0c21"
+checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
 dependencies = [
- "alloy-consensus-any 0.11.0",
- "alloy-rpc-types-eth 0.11.0",
- "alloy-serde 0.11.0",
+ "alloy-consensus-any 0.11.1",
+ "alloy-rpc-types-eth 0.11.1",
+ "alloy-serde 0.11.1",
 ]
 
 [[package]]
@@ -687,17 +687,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4a43d8b1344e3ef115ed7a2cee934876e4a64d2b9d9bee8738f9806900757e"
+checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
 dependencies = [
- "alloy-consensus 0.11.0",
- "alloy-consensus-any 0.11.0",
- "alloy-eips 0.11.0",
- "alloy-network-primitives 0.11.0",
+ "alloy-consensus 0.11.1",
+ "alloy-consensus-any 0.11.1",
+ "alloy-eips 0.11.1",
+ "alloy-network-primitives 0.11.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.11.0",
+ "alloy-serde 0.11.1",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86aa42c36e3c0db5bd9a7314e98aa261a61d5e3d6a0bd7e51fb8b0a3d6438481"
+checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -743,13 +743,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c613222abd016e03ba548f41db938a2c99108b59c0c66ca105eab1b7a2e6b40a"
+checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
 dependencies = [
  "alloy-primitives",
  "async-trait",
  "auto_impl",
+ "either",
  "elliptic-curve",
  "k256",
  "thiserror 2.0.11",
@@ -773,14 +774,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39163b956c81e8fd9605194d6b5b92dd93b0e0252810e69f9a4cebe3a8614f46"
+checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
 dependencies = [
- "alloy-consensus 0.11.0",
- "alloy-network 0.11.0",
+ "alloy-consensus 0.11.1",
+ "alloy-network 0.11.1",
  "alloy-primitives",
- "alloy-signer 0.11.0",
+ "alloy-signer 0.11.1",
  "async-trait",
  "k256",
  "rand",
@@ -1642,6 +1643,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -1886,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
 dependencies = [
  "cc",
  "glob",
@@ -2141,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "jobserver",
  "libc",
@@ -3098,9 +3100,9 @@ checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "document-features"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
@@ -3337,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -5308,6 +5310,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5348,6 +5360,23 @@ name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.2.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
 
 [[package]]
 name = "native-tls"
@@ -5646,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -5678,9 +5707,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -6458,9 +6487,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -6468,12 +6497,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -6543,7 +6572,7 @@ dependencies = [
  "bytes",
  "getrandom 0.2.15",
  "rand",
- "ring 0.17.8",
+ "ring 0.17.9",
  "rustc-hash 2.1.1",
  "rustls 0.23.23",
  "rustls-pki-types",
@@ -6556,9 +6585,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -6824,6 +6853,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -6894,15 +6924,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -7287,7 +7316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring 0.17.9",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -7300,7 +7329,7 @@ checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.8",
+ "ring 0.17.9",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -7352,7 +7381,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.9",
  "untrusted 0.9.0",
 ]
 
@@ -7362,7 +7391,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.9",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -7524,7 +7553,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.9",
  "untrusted 0.9.0",
 ]
 
@@ -7908,9 +7937,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
@@ -8322,8 +8351,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a42587153add9b7fdb4c0931b9e805bd6ab05e63e5837246e0b2594417c2a479"
 dependencies = [
  "alloy-primitives",
- "alloy-signer 0.11.0",
- "alloy-signer-local 0.11.0",
+ "alloy-signer 0.11.1",
+ "alloy-signer-local 0.11.1",
  "alloy-sol-types",
  "anyhow",
  "async-trait",
@@ -8739,6 +8768,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
+ "bincode",
  "brotli",
  "bytes",
  "color-eyre",
@@ -8770,9 +8800,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "a40f762a77d2afa88c2d919489e390a12bdd261ed568e60cfa7e48d4e20f0d33"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = { version = "0.12.2", default-features = false, features = [
     "json",
     "stream",
     "rustls-tls",
+    "multipart"
 ] }
 dotenv = "0.15.0"
 futures-util = "0.3.30"

--- a/crates/taralli-primitives/Cargo.toml
+++ b/crates/taralli-primitives/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 lazy_static = { workspace = true }
 async-trait = { workspace = true }
+serde_bytes = "=0.11.15"
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/taralli-primitives/Cargo.toml
+++ b/crates/taralli-primitives/Cargo.toml
@@ -10,7 +10,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 lazy_static = { workspace = true }
 async-trait = { workspace = true }
-serde_bytes = "=0.11.15"
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/taralli-primitives/src/request.rs
+++ b/crates/taralli-primitives/src/request.rs
@@ -14,3 +14,31 @@ pub struct Request<I: ProvingSystemInformation> {
     pub onchain_proof_request: OnChainProofRequest,
     pub signature: PrimitiveSignature,
 }
+
+/// There's a need for a strip down `Request` that doesn't contain the whole `proving_system_information` within itself.
+/// That so we can more easily send request data across the network, given how big `proving_system_information` can be.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PartialRequest {
+    pub proving_system_id: ProvingSystemId,
+    pub onchain_proof_request: OnChainProofRequest,
+    pub signature: PrimitiveSignature,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RequestCompressed {
+    pub proving_system_id: ProvingSystemId,
+    pub proving_system_information: Vec<u8>,
+    pub onchain_proof_request: OnChainProofRequest,
+    pub signature: PrimitiveSignature,
+}
+
+impl From<(PartialRequest, Vec<u8>)> for RequestCompressed {
+    fn from(value: (PartialRequest, Vec<u8>)) -> Self {
+        RequestCompressed {
+            proving_system_id: value.0.proving_system_id,
+            proving_system_information: value.1,
+            onchain_proof_request: value.0.onchain_proof_request,
+            signature: value.0.signature,
+        }
+    }
+}

--- a/crates/taralli-provider/src/api.rs
+++ b/crates/taralli-provider/src/api.rs
@@ -1,5 +1,6 @@
 use async_compression::tokio::bufread::BrotliDecoder;
 use futures::{Stream, StreamExt};
+use taralli_primitives::RequestCompressed;
 use tokio::net::TcpStream;
 
 use std::pin::Pin;
@@ -45,11 +46,12 @@ impl ProviderApi {
     /// * A byte vector containing the decompressed data
     async fn decompress_brotli(
         compressed_bytes: Vec<u8>,
-    ) -> std::result::Result<Vec<u8>, std::io::Error> {
+    ) -> std::result::Result<ProvingSystemParams, std::io::Error> {
         let mut decoder = BrotliDecoder::new(tokio::io::BufReader::new(&compressed_bytes[..]));
         let mut decompressed = Vec::new();
         decoder.read_to_end(&mut decompressed).await?;
-        Ok(decompressed)
+        let params = serde_json::from_slice(&decompressed)?;
+        Ok(params)
     }
 
     /// Parse a WebSocket stream into a stream of requests
@@ -71,30 +73,35 @@ impl ProviderApi {
             match message_result {
                 // This is the only case we care about.
                 // We expect the server to send us Brotli-compressed binary messages.
-                Ok(Message::Binary(compressed_bytes)) => {
-                    tracing::info!("Received Brotli-compressed binary message");
+                Ok(Message::Binary(bytes)) => {
+                    let request_compressed: RequestCompressed = match bincode::deserialize(&bytes) {
+                        Ok(rc) => rc,
+                        Err(e) => {
+                            tracing::info!("Couldn't deserialize data from WebSocket");
+                            return Some(Err(ProviderError::RequestParsingError(format!(
+                                "Failed to deserialize WebSocket data: {:?}", e
+                            ))));
+                        }
+                    };
 
                     // First we need to decompress the bytes.
-                    let decompressed_bytes =
-                        match ProviderApi::decompress_brotli(compressed_bytes.to_vec()).await {
+                    let proving_system_information: ProvingSystemParams =
+                        match ProviderApi::decompress_brotli(request_compressed.proving_system_information).await {
                             Ok(decompressed) => decompressed,
                             Err(e) => {
-                                tracing::error!("Failed to decompress WebSocket data: {:?}", e);
+                                tracing::error!("Failed to decompress proving system information: {:?}", e);
                                 return Some(Err(ProviderError::RequestParsingError(format!(
-                                    "Failed to decompress WebSocket data: {e}"
+                                    "Failed to decompress roving system information data: {e}"
                                 ))));
                             }
                         };
 
-                    // Then deserialize the JSON from decompressed bytes
-                    match serde_json::from_slice::<Request<ProvingSystemParams>>(
-                        &decompressed_bytes,
-                    ) {
-                        Ok(parsed) => Some(Ok(parsed)),
-                        Err(e) => Some(Err(ProviderError::RequestParsingError(format!(
-                            "JSON parse error after decompression: {e}"
-                        )))),
-                    }
+                    Some(Ok(Request::<ProvingSystemParams> {
+                        proving_system_id: request_compressed.proving_system_id,
+                        proving_system_information,
+                        onchain_proof_request: request_compressed.onchain_proof_request,
+                        signature: request_compressed.signature
+                    }))
                 }
                 Ok(Message::Frame(_)) => {
                     tracing::info!("Received unexpected frame message.");

--- a/crates/taralli-provider/src/api.rs
+++ b/crates/taralli-provider/src/api.rs
@@ -99,7 +99,7 @@ impl ProviderApi {
                                     e
                                 );
                                 return Some(Err(ProviderError::RequestParsingError(format!(
-                                    "Failed to decompress roving system information data: {e}"
+                                    "Failed to decompress proving system information data: {e}"
                                 ))));
                             }
                         };

--- a/crates/taralli-requester/src/api.rs
+++ b/crates/taralli-requester/src/api.rs
@@ -78,22 +78,21 @@ impl RequesterApi {
 
     /// Returns Multipart request Form with two parts: `ProvingSystemParams` as a `application/octet-stream` and remaining
     /// fields as `application/json`.
-    ///
     fn build_multipart(&self, request: Request<ProvingSystemParams>) -> Result<multipart::Form> {
-        let metadata = json!({
+        let partial_request = json!({
             "proving_system_id": request.proving_system_id,
             "onchain_proof_request": request.onchain_proof_request,
             "signature": request.signature,
         });
-        let metadata_string = serde_json::to_string(&metadata)
+        let partial_request_string = serde_json::to_string(&partial_request)
             .map_err(|e| RequesterError::RequestSubmissionFailed(e.to_string()))?;
-        let metadata_part = multipart::Part::text(metadata_string);
+        let partial_request_part = multipart::Part::text(partial_request_string);
 
         let compressed = self.compress_circuit(request.proving_system_information)?;
         let compressed_part = multipart::Part::bytes(compressed);
 
         let form = multipart::Form::new()
-            .part("metadata", metadata_part)
+            .part("partial_request", partial_request_part)
             .part("proving_system_information", compressed_part);
 
         Ok(form)

--- a/crates/taralli-requester/src/api.rs
+++ b/crates/taralli-requester/src/api.rs
@@ -38,9 +38,9 @@ impl RequesterApi {
         }
     }
 
-    /// Compresses the circuit using Brotli and returns the it as a byte vector
+    /// Compresses the proving system information using Brotli and returns the it as a byte vector
     /// # Arguments
-    /// * `circuit` - The circuit to be compressed
+    /// * `proving_system_information` - The proving system information to be compressed
     /// # Returns
     /// * A byte vector containing the compressed payloa
     /// # Details
@@ -48,7 +48,10 @@ impl RequesterApi {
     /// via the environment variables.
     /// Furthermore, we chose to instantiate a new compressor for each request
     /// if the need to submit multiple requests concurrently arises.
-    fn compress_circuit(&self, circuit: ProvingSystemParams) -> Result<Vec<u8>> {
+    fn compress_proving_system_information(
+        &self,
+        proving_system_information: ProvingSystemParams,
+    ) -> Result<Vec<u8>> {
         // We opt for some default values that may be reasonable for the general use case.
         let mut brotli_encoder = brotli::CompressorWriter::new(
             Vec::new(),
@@ -66,7 +69,7 @@ impl RequesterApi {
                 .unwrap_or(24),
         );
 
-        let payload = serde_json::to_string(&circuit)
+        let payload = serde_json::to_string(&proving_system_information)
             .map_err(|e| RequesterError::RequestSubmissionFailed(e.to_string()))?;
 
         brotli_encoder
@@ -88,7 +91,8 @@ impl RequesterApi {
             .map_err(|e| RequesterError::RequestSubmissionFailed(e.to_string()))?;
         let partial_request_part = multipart::Part::text(partial_request_string);
 
-        let compressed = self.compress_circuit(request.proving_system_information)?;
+        let compressed =
+            self.compress_proving_system_information(request.proving_system_information)?;
         let compressed_part = multipart::Part::bytes(compressed);
 
         let form = multipart::Form::new()

--- a/crates/taralli-server/Cargo.toml
+++ b/crates/taralli-server/Cargo.toml
@@ -19,16 +19,21 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 async-trait = { workspace = true }
 color-eyre = { workspace = true }
-axum = { version = "0.7.4", features = ["ws"] }
+axum = { version = "0.7.4", features = ["ws", "multipart"] }
 base64 = "0.22.0"
 bytes = "1.6.0"
 tokio-stream = "0.1.14"
 tokio-util = { workspace = true }
-tower-http = { version = "0.6.2", features = ["compression-full", "decompression-full", "trace"] }
+tower-http = { version = "0.6.2", features = [
+    "compression-full",
+    "decompression-full",
+    "trace",
+] }
 async-stream = "0.3.5"
 hex = "0.4.3"
 hyper = "1.6.0"
 http-body-util = "0.1.2"
+bincode = "1.3.3"
 
 [dev-dependencies]
 tower = { version = "0.5.1", features = ["util"] }

--- a/crates/taralli-server/src/brotli.rs
+++ b/crates/taralli-server/src/brotli.rs
@@ -1,41 +1,84 @@
 use axum::{
     async_trait,
     body::Body,
-    extract::{FromRequest, Request},
+    extract::{FromRequest, Multipart, Request},
     http::StatusCode,
 };
-use brotli::Decompressor;
-use std::io::{Cursor, Read};
+use taralli_primitives::PartialRequest;
 
 /// A custom extractor that retains both the compressed and decompressed versions.
-/// Todo: Remove the decompressed version and only retain the compressed version when/if we stop validation on the server (on submit).
-pub struct BrotliFile {
-    pub compressed: Vec<u8>,
-    pub decompressed: Vec<u8>,
+pub struct SubmittedRequest {
+    pub partial_request: PartialRequest,
+    pub proving_system_information_bytes: Vec<u8>,
 }
 
 #[async_trait]
-impl<S> FromRequest<S> for BrotliFile
+impl<S> FromRequest<S> for SubmittedRequest
 where
     S: Send + Sync,
 {
-    type Rejection = (StatusCode, &'static str);
+    type Rejection = (StatusCode, String);
 
-    async fn from_request(req: Request<Body>, _state: &S) -> Result<Self, Self::Rejection> {
-        let body_bytes = hyper::body::Bytes::from_request(req, _state)
+    async fn from_request(req: Request<Body>, state: &S) -> Result<Self, Self::Rejection> {
+        let mut multipart = Multipart::from_request(req, state)
             .await
-            .map_err(|_| (StatusCode::BAD_REQUEST, "Error reading request body"))?
-            .to_vec();
+            .map_err(|e| (e.status(), e.body_text()))?;
 
-        let mut decompressor = Decompressor::new(Cursor::new(&body_bytes), 4096);
-        let mut decompressed_data = Vec::new();
-        decompressor
-            .read_to_end(&mut decompressed_data)
-            .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid Brotli file"))?;
+        let mut partial_request: Option<PartialRequest> = None;
+        let mut proving_system_information_bytes: Option<Vec<u8>> = None;
+        while let Some(part) = multipart
+            .next_field()
+            .await
+            .map_err(|e| (e.status(), e.body_text()))?
+        {
+            match part.name() {
+                Some("metadata") => {
+                    let bytes = part
+                        .bytes()
+                        .await
+                        .map_err(|e| (e.status(), e.body_text()))?;
+                    partial_request = Some(serde_json::from_slice(&bytes).map_err(|_| {
+                        (
+                            StatusCode::BAD_REQUEST,
+                            "Invalid JSON in partial request".to_string(),
+                        )
+                    })?);
+                }
+                Some("proving_system_information") => {
+                    let bytes = part.bytes().await.map_err(|_| {
+                        (
+                            StatusCode::BAD_REQUEST,
+                            "Error reading proving system information as binary".to_string(),
+                        )
+                    })?;
+                    proving_system_information_bytes = Some(bytes.to_vec());
+                }
+                Some(_s) => {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "Field not recognized on submission".to_string(),
+                    ));
+                }
+                None => {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "Missing name for some submitted field".to_string(),
+                    ))
+                }
+            }
+        }
 
-        Ok(BrotliFile {
-            compressed: body_bytes,
-            decompressed: decompressed_data,
+        // The `ok_or()` clauses below should never trigger, any error should've been filtered above.
+        // Nonetheless, I'm opting for this rather than std::mem::MaybeUninit for the sake of making sure we're not returning something empty.
+        Ok(SubmittedRequest {
+            partial_request: partial_request.ok_or((
+                StatusCode::BAD_REQUEST,
+                "Missing partial request data".to_string(),
+            ))?,
+            proving_system_information_bytes: proving_system_information_bytes.ok_or((
+                StatusCode::BAD_REQUEST,
+                "Missing proving system information as binary".to_string(),
+            ))?,
         })
     }
 }

--- a/crates/taralli-server/src/lib.rs
+++ b/crates/taralli-server/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod app_state;
-pub mod brotli;
 pub mod config;
 pub mod error;
+pub mod extracted_request;
 pub mod routes;
 pub mod subscription_manager;
 pub mod validation;

--- a/crates/taralli-server/src/subscription_manager.rs
+++ b/crates/taralli-server/src/subscription_manager.rs
@@ -55,7 +55,6 @@ where
     }
 }
 
-// Should not have this default? Maybe env var
 impl<M> Default for SubscriptionManager<M>
 where
     M: Clone,

--- a/crates/taralli-server/src/validation.rs
+++ b/crates/taralli-server/src/validation.rs
@@ -8,33 +8,30 @@ use taralli_primitives::alloy::{
     providers::Provider,
     transports::Transport,
 };
-use taralli_primitives::systems::ProvingSystemInformation;
-use taralli_primitives::validation::validate_request;
-use taralli_primitives::Request;
+use taralli_primitives::validation::validate_partial_request;
+use taralli_primitives::PartialRequest;
 use tokio::time::timeout;
 
-pub async fn validate_proof_request<T, P, I>(
-    request: &Request<I>,
+pub async fn validate_proof_request<T, P>(
+    request: &PartialRequest,
     app_state: &State<AppState<T, P>>,
     timeout_seconds: Duration,
 ) -> Result<()>
 where
     T: Transport + Clone,
     P: Provider<T> + Clone,
-    I: ProvingSystemInformation + Clone,
 {
     // TODO: remove this async process from the validation execution of the server and use input parameter instead
     let latest_timestamp = get_latest_timestamp(app_state.rpc_provider()).await?;
 
     timeout(timeout_seconds, async {
-        validate_request(
+        validate_partial_request(
             request,
             latest_timestamp,
             &app_state.market_address(),
             app_state.minimum_allowed_proving_time(),
             app_state.maximum_allowed_start_delay(),
             app_state.maximum_allowed_stake(),
-            &app_state.supported_proving_systems(),
         )?;
         Ok(())
     })


### PR DESCRIPTION
A few changes to the submit, broadcast, subscribe workflow:
- Submit() (Requester) requests are now done via HTTP Multipart, with all request data sent as text, whilst proving system information is sent as compressed bytes.
- Upon receival, data is placed under a `RequestCompressed` type, serialized to binary and sent across to subscriptions via tokio::mpmc.
- Providers then receive Request as bytes, deserialize it, then decompress the proving system information.