### PR TITLE
Small tidy: better CI caching and clippy:pedantic

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -27,6 +27,8 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        cache-directories: "**/target"
+        cache-on-failure: true
 
     - name: Run fmt
       run: cargo +nightly-2025-03-05 fmt -- --check
@@ -67,7 +69,9 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        shared-key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+        cache-directories: "**/target"
+        cache-on-failure: true
 
     - name: Run tests
       run: cargo +nightly-2025-03-05 test --locked --verbose

--- a/bin/offering-client/src/bin/arkworks_offering.rs
+++ b/bin/offering-client/src/bin/arkworks_offering.rs
@@ -178,7 +178,7 @@ async fn main() -> Result<()> {
 
     // submit and track ComputeOffer
     provider
-        .submit_and_track(signed_offer, auction_length as u64)
+        .submit_and_track(signed_offer, u64::from(auction_length))
         .await?;
     Ok(())
 }

--- a/bin/offering-client/src/bin/risc0_bonsai_offering.rs
+++ b/bin/offering-client/src/bin/risc0_bonsai_offering.rs
@@ -175,7 +175,7 @@ async fn main() -> Result<()> {
 
     // submit and track ComputeOffer
     provider
-        .submit_and_track(signed_offer, auction_length as u64)
+        .submit_and_track(signed_offer, u64::from(auction_length))
         .await?;
     Ok(())
 }

--- a/bin/offering-client/src/bin/risc0_offering.rs
+++ b/bin/offering-client/src/bin/risc0_offering.rs
@@ -175,7 +175,7 @@ async fn main() -> Result<()> {
 
     // submit and track ComputeOffer
     provider
-        .submit_and_track(signed_offer, auction_length as u64)
+        .submit_and_track(signed_offer, u64::from(auction_length))
         .await?;
     Ok(())
 }

--- a/bin/offering-client/src/bin/sp1_offering.rs
+++ b/bin/offering-client/src/bin/sp1_offering.rs
@@ -176,7 +176,7 @@ async fn main() -> Result<()> {
 
     // submit and track ComputeOffer
     provider
-        .submit_and_track(signed_offer, auction_length as u64)
+        .submit_and_track(signed_offer, u64::from(auction_length))
         .await?;
     Ok(())
 }

--- a/bin/offering-client/src/bin/sp1_succint_offering.rs
+++ b/bin/offering-client/src/bin/sp1_succint_offering.rs
@@ -184,7 +184,7 @@ async fn main() -> Result<()> {
 
     // submit and track ComputeOffer
     provider
-        .submit_and_track(signed_offer, auction_length as u64)
+        .submit_and_track(signed_offer, u64::from(auction_length))
         .await?;
     Ok(())
 }

--- a/bin/requesting-client/src/bin/arkworks_requester.rs
+++ b/bin/requesting-client/src/bin/arkworks_requester.rs
@@ -173,7 +173,7 @@ async fn main() -> Result<()> {
 
     // submit and track ComputeRequest
     requester
-        .submit_and_track(signed_request, auction_length as u64)
+        .submit_and_track(signed_request, u64::from(auction_length))
         .await?;
     Ok(())
 }

--- a/bin/requesting-client/src/bin/risc0_requester.rs
+++ b/bin/requesting-client/src/bin/risc0_requester.rs
@@ -157,7 +157,7 @@ async fn main() -> Result<()> {
 
     // submit and track ComputeRequest
     requester
-        .submit_and_track(signed_request, auction_length as u64)
+        .submit_and_track(signed_request, u64::from(auction_length))
         .await?;
 
     Ok(())

--- a/bin/requesting-client/src/bin/sp1_requester.rs
+++ b/bin/requesting-client/src/bin/sp1_requester.rs
@@ -159,7 +159,7 @@ async fn main() -> Result<()> {
 
     // submit and track ComputeRequest
     requester
-        .submit_and_track(signed_request, auction_length as u64)
+        .submit_and_track(signed_request, u64::from(auction_length))
         .await?;
 
     Ok(())

--- a/bin/server/src/bin/server.rs
+++ b/bin/server/src/bin/server.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<()> {
     let base_state = BaseState::new(
         rpc_provider.clone(),
         config.markets,
-        Duration::from_secs(config.validation_timeout_seconds as u64),
+        Duration::from_secs(u64::from(config.validation_timeout_seconds)),
         validation_configs,
     );
     let request_state = RequestState::new(base_state.clone(), subscription_manager);

--- a/crates/taralli-client/src/analyzer/offer.rs
+++ b/crates/taralli-client/src/analyzer/offer.rs
@@ -15,7 +15,7 @@ use crate::error::Result;
 
 use super::IntentAnalyzer;
 
-/// Analyzes a ComputeOffer's validity and profitability
+/// Analyzes a `ComputeOffer`'s validity and profitability
 pub struct ComputeOfferAnalyzer<T, P, N>
 where
     T: Transport + Clone + Send + Sync,

--- a/crates/taralli-client/src/analyzer/request.rs
+++ b/crates/taralli-client/src/analyzer/request.rs
@@ -15,7 +15,7 @@ use crate::error::Result;
 
 use super::IntentAnalyzer;
 
-/// Analyzes a ComputeRequest's validity and profitability
+/// Analyzes a `ComputeRequest`'s validity and profitability
 pub struct ComputeRequestAnalyzer<T, P, N>
 where
     T: Transport + Clone + Send + Sync,

--- a/crates/taralli-client/src/api/query.rs
+++ b/crates/taralli-client/src/api/query.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use crate::error::{ClientError, Result};
 
-/// Query ComputeOffers stored within the protocol server's intent db
+/// Query `ComputeOffers` stored within the protocol server's intent db
 pub struct QueryApiClient {
     _api_key: String,
     client: Client,
@@ -20,6 +20,7 @@ pub struct QueryApiClient {
 }
 
 impl QueryApiClient {
+    #[must_use]
     pub fn new(server_url: Url) -> Self {
         let mut headers = HeaderMap::new();
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
@@ -80,7 +81,7 @@ impl QueryApiClient {
         let json: serde_json::Value = serde_json::from_str(&response_text).map_err(|e| {
             tracing::error!("Failed to parse JSON response: {}", e);
             tracing::debug!("Response text: {}", response_text);
-            ClientError::ServerRequestError(format!("Invalid JSON response: {}", e))
+            ClientError::ServerRequestError(format!("Invalid JSON response: {e}"))
         })?;
 
         let offers = json.get("intents").ok_or_else(|| {
@@ -93,7 +94,7 @@ impl QueryApiClient {
         let stored_intents: Vec<StoredIntent> =
             serde_json::from_value(offers.clone()).map_err(|e| {
                 tracing::error!("Failed to parse stored intents: {}", e);
-                ClientError::ServerRequestError(format!("Failed to parse stored intents: {}", e))
+                ClientError::ServerRequestError(format!("Failed to parse stored intents: {e}"))
             })?;
 
         if stored_intents.is_empty() {
@@ -112,9 +113,7 @@ impl QueryApiClient {
                 result
             })
             .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|e| {
-                ClientError::ServerRequestError(format!("Failed to parse offers: {}", e))
-            })?;
+            .map_err(|e| ClientError::ServerRequestError(format!("Failed to parse offers: {e}")))?;
 
         tracing::info!("Successfully parsed {} offers", offers.len());
 

--- a/crates/taralli-client/src/api/submit.rs
+++ b/crates/taralli-client/src/api/submit.rs
@@ -19,6 +19,7 @@ pub struct SubmitApiClient {
 }
 
 impl SubmitApiClient {
+    #[must_use]
     pub fn new(server_url: Url) -> Self {
         let mut headers = HeaderMap::new();
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));

--- a/crates/taralli-client/src/api/subscribe.rs
+++ b/crates/taralli-client/src/api/subscribe.rs
@@ -25,7 +25,7 @@ use crate::error::{ClientError, Result};
 pub type ComputeRequestStream =
     Pin<Box<dyn Stream<Item = Result<ComputeRequest<SystemParams>>> + Send>>;
 
-/// Subscribe over websocket stream to broadcasts as new ComputeRequest's are submitted to
+/// Subscribe over websocket stream to broadcasts as new `ComputeRequest`'s are submitted to
 /// the protocol server
 pub struct SubscribeApiClient {
     server_url: Url,
@@ -34,6 +34,7 @@ pub struct SubscribeApiClient {
 }
 
 impl SubscribeApiClient {
+    #[must_use]
     pub fn new(server_url: Url, subscribe_to: SystemIdMask) -> Self {
         let mut api_key = String::new();
         if Environment::from_env_var() == Environment::Production {
@@ -86,7 +87,7 @@ impl SubscribeApiClient {
                                 Ok(rc) => rc,
                                 Err(e) => {
                                     let err = Err(ClientError::IntentParsingError(
-                                        format!("Failed to deserialize WebSocket data: {:?}", e)
+                                        format!("Failed to deserialize WebSocket data: {e:?}")
                                     ));
                                     // Yield an error item but continue the stream
                                     return Some((err, (listener, shutdown_receiver)));
@@ -173,7 +174,7 @@ impl SubscribeApiClient {
             "https" => "wss",
             other => other,
         };
-        url.set_scheme(new_scheme).map_err(|_| {
+        url.set_scheme(new_scheme).map_err(|()| {
             ClientError::ServerSubscriptionError("Invalid WebSocket scheme".to_string())
         })?;
 
@@ -285,7 +286,7 @@ impl SubscribeApiClient {
     }
 }
 
-/// Wrapper around the ComputeRequestStream type.
+/// Wrapper around the `ComputeRequestStream` type.
 /// The intent here is to implement a custom `Drop` so we can set the closing of WebSocket conns.
 pub struct CleanupStream {
     inner: ComputeRequestStream,

--- a/crates/taralli-client/src/bidder/offer.rs
+++ b/crates/taralli-client/src/bidder/offer.rs
@@ -12,7 +12,7 @@ use taralli_primitives::alloy::transports::Transport;
 
 use super::IntentBidder;
 
-/// Bid on a ComputeOffer
+/// Bid on a `ComputeOffer`
 #[derive(Clone)]
 pub struct ComputeOfferBidder<T, P, N> {
     rpc_provider: P,

--- a/crates/taralli-client/src/bidder/request.rs
+++ b/crates/taralli-client/src/bidder/request.rs
@@ -14,7 +14,7 @@ use tokio::time::{sleep, Duration};
 
 use super::IntentBidder;
 
-/// Bid on a ComputeRequest
+/// Bid on a `ComputeRequest`
 #[derive(Clone)]
 pub struct ComputeRequestBidder<T, P, N> {
     rpc_provider: P,
@@ -191,6 +191,6 @@ fn calculate_target_timestamp(
 
     // Convert U256 back to u64
     target_timestamp.try_into().map_err(|e| {
-        ClientError::TransactionSetupError(format!("Failed to convert target timestamp: {}", e))
+        ClientError::TransactionSetupError(format!("Failed to convert target timestamp: {e}"))
     })
 }

--- a/crates/taralli-client/src/client/provider/offering.rs
+++ b/crates/taralli-client/src/client/provider/offering.rs
@@ -87,7 +87,7 @@ where
 
         // compute resolve deadline timestamp
         let _resolve_deadline =
-            offer.proof_offer.endAuctionTimestamp + offer.proof_offer.provingTime as u64;
+            offer.proof_offer.endAuctionTimestamp + u64::from(offer.proof_offer.provingTime);
 
         // setup tracking
         let auction_tracker = self
@@ -110,7 +110,7 @@ where
         if !response.status().is_success() {
             // Parse the error response
             let error_body = response.json::<serde_json::Value>().await.map_err(|e| {
-                ClientError::ServerRequestError(format!("Failed to parse error response: {}", e))
+                ClientError::ServerRequestError(format!("Failed to parse error response: {e}"))
             })?;
 
             return Err(ClientError::IntentSubmissionFailed(format!(
@@ -141,7 +141,7 @@ where
         self.resolver
             .resolve_intent(offer_id, work_result.opaque_submission)
             .await
-            .map_err(|e| ClientError::TransactionFailure(format!("resolver failed: {}", e)))?;
+            .map_err(|e| ClientError::TransactionFailure(format!("resolver failed: {e}")))?;
 
         tracing::info!("Compute offer resolved");
         Ok(())

--- a/crates/taralli-client/src/client/provider/streaming.rs
+++ b/crates/taralli-client/src/client/provider/streaming.rs
@@ -31,8 +31,8 @@ use crate::{
 };
 use crate::{api::subscribe::SubscribeApiClient, client::BaseClient};
 
-/// Client that fulfills ComputeRequests by subscribing to the protocol server over websocket
-/// stream to receive newly submitted ComputeRequests at the given system IDs they subscribed to.
+/// Client that fulfills `ComputeRequests` by subscribing to the protocol server over websocket
+/// stream to receive newly submitted `ComputeRequests` at the given system IDs they subscribed to.
 /// It then processes the incoming compute requests, bids upon them, compute's the requested compute
 /// workload and then resolves the compute request within the market contract.
 pub struct ProviderStreamingClient<T, P, N, S>
@@ -78,7 +78,7 @@ where
     }
 
     /// Register a system configuration with the client for a specific system
-    /// (systemID -> ComputeWorker + Validator)
+    /// (systemID -> `ComputeWorker` + Validator)
     pub fn with_system_configuration<
         W: ComputeWorker<ComputeRequest<SystemParams>> + Send + Sync + 'static,
     >(
@@ -177,7 +177,7 @@ where
                 request.signature,
             )
             .await
-            .map_err(|e| ClientError::TransactionFailure(format!("bid txs failed: {}", e)))?;
+            .map_err(|e| ClientError::TransactionFailure(format!("bid txs failed: {e}")))?;
 
         tracing::info!("bid transaction submitted successfully");
 
@@ -194,7 +194,7 @@ where
         self.resolver
             .resolve_intent(request_id, work_result.opaque_submission)
             .await
-            .map_err(|e| ClientError::TransactionFailure(format!("resolve txs failed: {}", e)))?;
+            .map_err(|e| ClientError::TransactionFailure(format!("resolve txs failed: {e}")))?;
 
         tracing::info!("resolve transaction submitted");
 

--- a/crates/taralli-client/src/client/requester/requesting.rs
+++ b/crates/taralli-client/src/client/requester/requesting.rs
@@ -21,7 +21,7 @@ use crate::{
 
 use crate::client::BaseClient;
 
-/// Client that submits signed ComputeRequest to the protocol server, tracks their auction status
+/// Client that submits signed `ComputeRequest` to the protocol server, tracks their auction status
 /// and then tracks their resolution status to see if the requested compute workload was fulfilled.
 pub struct RequesterRequestingClient<T, P, N, S>
 where
@@ -77,8 +77,8 @@ where
         let request_id = request.compute_id();
 
         // compute resolve deadline timestamp
-        let resolve_deadline =
-            request.proof_request.endAuctionTimestamp + request.proof_request.provingTime as u64;
+        let resolve_deadline = request.proof_request.endAuctionTimestamp
+            + u64::from(request.proof_request.provingTime);
 
         // setup tracking
         let auction_tracker = self
@@ -111,12 +111,12 @@ where
             let error_message = match serde_json::from_str::<serde_json::Value>(&error_text) {
                 Ok(json) => {
                     if let Some(error) = json.get("error").and_then(|e| e.as_str()) {
-                        format!("Server validation failed: {}", error)
+                        format!("Server validation failed: {error}")
                     } else {
-                        format!("Server returned error: {}", error_text)
+                        format!("Server returned error: {error_text}")
                     }
                 }
-                Err(_) => format!("Server returned error: {}", error_text),
+                Err(_) => format!("Server returned error: {error_text}"),
             };
 
             return Err(ClientError::IntentSubmissionFailed(error_message));

--- a/crates/taralli-client/src/client/requester/searching.rs
+++ b/crates/taralli-client/src/client/requester/searching.rs
@@ -95,7 +95,7 @@ where
 
         // compute resolve deadline timestamp
         let resolve_deadline_ts =
-            offer.proof_offer.endAuctionTimestamp + offer.proof_offer.provingTime as u64;
+            offer.proof_offer.endAuctionTimestamp + u64::from(offer.proof_offer.provingTime);
 
         // analyze the validity and profitability of the offer
         self.analyzer
@@ -114,7 +114,7 @@ where
                 offer.signature,
             )
             .await
-            .map_err(|e| ClientError::TransactionFailure(format!("bid txs failed: {}", e)))?;
+            .map_err(|e| ClientError::TransactionFailure(format!("bid txs failed: {e}")))?;
 
         tracing::info!("bid transaction submitted successfully, tracking resolution of the offer");
 

--- a/crates/taralli-client/src/intent_builder/mod.rs
+++ b/crates/taralli-client/src/intent_builder/mod.rs
@@ -95,7 +95,7 @@ where
         }
     }
 
-    /// return the RequestBuilder with the added permit2 nonce
+    /// return the `RequestBuilder` with the added permit2 nonce
     pub async fn set_new_nonce(mut self) -> Result<Self> {
         self.nonce = self
             .permit2_nonce_manager
@@ -105,7 +105,7 @@ where
         Ok(self)
     }
 
-    /// return the RequestBuilder with the added auction timestamps based on auction length
+    /// return the `RequestBuilder` with the added auction timestamps based on auction length
     /// and the current latest block timestamp
     pub async fn set_auction_timestamps_from_auction_length(mut self) -> Result<Self> {
         if self.auction_length == 0 {
@@ -133,12 +133,12 @@ where
             .ok_or_else(|| ClientError::RpcRequestError("Latest block not found".to_string()))?;
 
         let start_auction_timestamp = latest_block.header().timestamp();
-        let end_auction_timestamp = start_auction_timestamp + auction_length as u64;
+        let end_auction_timestamp = start_auction_timestamp + u64::from(auction_length);
 
         Ok((start_auction_timestamp, end_auction_timestamp))
     }
 
-    /// return the IntentBuilder with the added auction time parameters
+    /// return the `IntentBuilder` with the added auction time parameters
     pub fn set_time_params(
         mut self,
         start_auction_ts: u64,
@@ -151,7 +151,7 @@ where
         self
     }
 
-    /// return the ProofRequest builder with the added verification commitments
+    /// return the `ProofRequest` builder with the added verification commitments
     pub fn set_verification_commitment_params(
         mut self,
         inputs_commitment: B256,
@@ -168,6 +168,7 @@ where
     }
 
     /// create dummy ECDSA signature
+    #[must_use]
     pub fn create_dummy_signature() -> PrimitiveSignature {
         PrimitiveSignature::try_from(&MOCK_SIGNATURE_BYTES[..])
             .expect("Unreachable: Mock Signature try from failure")

--- a/crates/taralli-client/src/intent_builder/offer.rs
+++ b/crates/taralli-client/src/intent_builder/offer.rs
@@ -13,7 +13,7 @@ use super::{BaseIntentBuilder, IntentBuilder};
 use crate::error::Result;
 use crate::nonce_manager::Permit2NonceManager;
 
-/// Intent builder for ComputeOffers
+/// Intent builder for `ComputeOffers`
 #[derive(Clone)]
 pub struct ComputeOfferBuilder<T, P, N>
 where

--- a/crates/taralli-client/src/intent_builder/request.rs
+++ b/crates/taralli-client/src/intent_builder/request.rs
@@ -14,7 +14,7 @@ use super::{BaseIntentBuilder, IntentBuilder};
 use crate::error::Result;
 use crate::nonce_manager::Permit2NonceManager;
 
-/// Intent builder for ComputeRequests
+/// Intent builder for `ComputeRequests`
 #[derive(Clone)]
 pub struct ComputeRequestBuilder<T, P, N>
 where

--- a/crates/taralli-client/src/resolver/offer.rs
+++ b/crates/taralli-client/src/resolver/offer.rs
@@ -13,7 +13,7 @@ use crate::error::{ClientError, Result};
 
 use super::IntentResolver;
 
-/// Resolver for ComputeOffers
+/// Resolver for `ComputeOffers`
 pub struct ComputeOfferResolver<T, P, N>
 where
     T: Transport + Clone,

--- a/crates/taralli-client/src/resolver/request.rs
+++ b/crates/taralli-client/src/resolver/request.rs
@@ -13,7 +13,7 @@ use crate::error::{ClientError, Result};
 
 use super::IntentResolver;
 
-/// Resolver for ComputeRequests
+/// Resolver for `ComputeRequests`
 pub struct ComputeRequestResolver<T, P, N>
 where
     T: Transport + Clone,

--- a/crates/taralli-client/src/searcher/offer.rs
+++ b/crates/taralli-client/src/searcher/offer.rs
@@ -11,7 +11,7 @@ use crate::error::{ClientError, Result};
 
 use super::IntentSearcher;
 
-/// Searcher for ComputeOffers
+/// Searcher for `ComputeOffers`
 pub struct ComputeOfferSearcher {
     api_client: QueryApiClient,
     system_id: SystemId,
@@ -19,6 +19,7 @@ pub struct ComputeOfferSearcher {
 }
 
 impl ComputeOfferSearcher {
+    #[must_use]
     pub fn new(server_url: Url, system_id: SystemId, market_address: Address) -> Self {
         Self {
             api_client: QueryApiClient::new(server_url),

--- a/crates/taralli-client/src/tracker/offer.rs
+++ b/crates/taralli-client/src/tracker/offer.rs
@@ -18,7 +18,7 @@ use crate::error::{ClientError, Result};
 
 use super::{IntentAuctionTracker, IntentResolveTracker};
 
-/// ComputeOffer tracker for both auctions and resolutions
+/// `ComputeOffer` tracker for both auctions and resolutions
 pub struct ComputeOfferTracker<T, P, N> {
     rpc_provider: P,
     market_address: Address,
@@ -84,12 +84,11 @@ where
         })
         .await;
 
-        match result {
-            Ok(event) => Ok(event),
-            Err(_) => {
-                tracing::info!("Auction watching timed out");
-                Ok(None)
-            }
+        if let Ok(event) = result {
+            Ok(event)
+        } else {
+            tracing::info!("Auction watching timed out");
+            Ok(None)
         }
     }
 }
@@ -138,12 +137,11 @@ where
         })
         .await;
 
-        match result {
-            Ok(event) => Ok(event),
-            Err(_) => {
-                tracing::info!("Auction watching timed out");
-                Ok(None)
-            }
+        if let Ok(event) = result {
+            Ok(event)
+        } else {
+            tracing::info!("Auction watching timed out");
+            Ok(None)
         }
     }
 }

--- a/crates/taralli-client/src/tracker/request.rs
+++ b/crates/taralli-client/src/tracker/request.rs
@@ -18,7 +18,7 @@ use crate::error::{ClientError, Result};
 
 use super::{IntentAuctionTracker, IntentResolveTracker};
 
-/// ComputeRequest tracker for both auctions and resolutons
+/// `ComputeRequest` tracker for both auctions and resolutons
 pub struct ComputeRequestTracker<T, P, N> {
     rpc_provider: P,
     market_address: Address,
@@ -84,12 +84,11 @@ where
         })
         .await;
 
-        match result {
-            Ok(event) => Ok(event),
-            Err(_) => {
-                tracing::info!("Auction watching timed out");
-                Ok(None)
-            }
+        if let Ok(event) = result {
+            Ok(event)
+        } else {
+            tracing::info!("Auction watching timed out");
+            Ok(None)
         }
     }
 }
@@ -138,12 +137,11 @@ where
         })
         .await;
 
-        match result {
-            Ok(event) => Ok(event),
-            Err(_) => {
-                tracing::info!("Auction watching timed out");
-                Ok(None)
-            }
+        if let Ok(event) = result {
+            Ok(event)
+        } else {
+            tracing::info!("Auction watching timed out");
+            Ok(None)
         }
     }
 }

--- a/crates/taralli-client/src/worker.rs
+++ b/crates/taralli-client/src/worker.rs
@@ -30,6 +30,7 @@ pub struct WorkerManager<I: ComputeIntent> {
 }
 
 impl<I: ComputeIntent> WorkerManager<I> {
+    #[must_use]
     pub fn new(
         workers: HashMap<SystemId, Arc<dyn ComputeWorker<I> + Send + Sync + 'static>>,
     ) -> Self {

--- a/crates/taralli-primitives/src/compression_utils/db.rs
+++ b/crates/taralli-primitives/src/compression_utils/db.rs
@@ -30,8 +30,7 @@ impl TryFrom<Row> for StoredIntent {
             Ok(bytes) => B256::from_slice(&bytes),
             Err(e) => {
                 return Err(PrimitivesError::DbSerializeError(format!(
-                    "Failed to get intent_id: {}",
-                    e
+                    "Failed to get intent_id: {e}"
                 )));
             }
         };
@@ -40,8 +39,7 @@ impl TryFrom<Row> for StoredIntent {
             Ok(id) => id,
             Err(e) => {
                 return Err(PrimitivesError::DbSerializeError(format!(
-                    "Failed to get system_id: {}",
-                    e
+                    "Failed to get system_id: {e}"
                 )));
             }
         };
@@ -50,8 +48,7 @@ impl TryFrom<Row> for StoredIntent {
             Ok(bytes) => bytes,
             Err(e) => {
                 return Err(PrimitivesError::DbSerializeError(format!(
-                    "Failed to get system: {}",
-                    e
+                    "Failed to get system: {e}"
                 )));
             }
         };
@@ -60,8 +57,7 @@ impl TryFrom<Row> for StoredIntent {
             Ok(bytes) => bytes,
             Err(e) => {
                 return Err(PrimitivesError::DbSerializeError(format!(
-                    "Failed to get proof_commitment: {}",
-                    e
+                    "Failed to get proof_commitment: {e}"
                 )));
             }
         };
@@ -70,8 +66,7 @@ impl TryFrom<Row> for StoredIntent {
             Ok(bytes) => bytes,
             Err(e) => {
                 return Err(PrimitivesError::DbSerializeError(format!(
-                    "Failed to get signature: {}",
-                    e
+                    "Failed to get signature: {e}"
                 )));
             }
         };
@@ -80,8 +75,7 @@ impl TryFrom<Row> for StoredIntent {
             Ok(ts) => ts,
             Err(e) => {
                 return Err(PrimitivesError::DbSerializeError(format!(
-                    "Failed to get expiration_ts: {}",
-                    e
+                    "Failed to get expiration_ts: {e}"
                 )));
             }
         };
@@ -90,8 +84,7 @@ impl TryFrom<Row> for StoredIntent {
             Ok(ts) => ts,
             Err(e) => {
                 return Err(PrimitivesError::DbSerializeError(format!(
-                    "Failed to get created_at: {}",
-                    e
+                    "Failed to get created_at: {e}"
                 )));
             }
         };
@@ -101,8 +94,7 @@ impl TryFrom<Row> for StoredIntent {
             Ok(ts) => ts,
             Err(e) => {
                 return Err(PrimitivesError::DbSerializeError(format!(
-                    "Failed to get expired_at: {}",
-                    e
+                    "Failed to get expired_at: {e}"
                 )));
             }
         };
@@ -120,7 +112,7 @@ impl TryFrom<Row> for StoredIntent {
     }
 }
 
-/// Convert a StoredIntent into a ComputeOffer
+/// Convert a `StoredIntent` into a `ComputeOffer`
 impl<S: System> TryFrom<StoredIntent> for ComputeOffer<S>
 where
     S: for<'de> serde::Deserialize<'de>,
@@ -136,39 +128,35 @@ where
 
         let mut decompressed_bytes = Vec::new();
         std::io::Read::read_to_end(&mut decompressor, &mut decompressed_bytes).map_err(|e| {
-            PrimitivesError::DbDeserializeError(format!("Failed to decompress system bytes: {}", e))
+            PrimitivesError::DbDeserializeError(format!("Failed to decompress system bytes: {e}"))
         })?;
 
         // Parse the decompressed system data
         let system = serde_json::from_slice::<S>(&decompressed_bytes).map_err(|e| {
             PrimitivesError::DbDeserializeError(format!(
-                "Failed to deserialize decompressed system: {}",
-                e
+                "Failed to deserialize decompressed system: {e}"
             ))
         })?;
 
         // Parse the proof_commitment from binary data
         let proof_offer = serde_json::from_slice(&stored.proof_commitment).map_err(|e| {
             PrimitivesError::DbDeserializeError(format!(
-                "Failed to deserialize proof_commitment: {}",
-                e
+                "Failed to deserialize proof_commitment: {e}"
             ))
         })?;
 
         // Convert system_id string to SystemId
-        let system_id = SystemId::try_from(stored.system_id.as_str()).map_err(|e| {
-            PrimitivesError::DbDeserializeError(format!("Invalid system_id: {}", e))
-        })?;
+        let system_id = SystemId::try_from(stored.system_id.as_str())
+            .map_err(|e| PrimitivesError::DbDeserializeError(format!("Invalid system_id: {e}")))?;
 
         // Convert signature bytes to Signature type
-        let signature = PrimitiveSignature::try_from(stored.signature.as_slice()).map_err(|e| {
-            PrimitivesError::DbDeserializeError(format!("Invalid signature: {}", e))
-        })?;
+        let signature = PrimitiveSignature::try_from(stored.signature.as_slice())
+            .map_err(|e| PrimitivesError::DbDeserializeError(format!("Invalid signature: {e}")))?;
 
         // Construct and return the ComputeOffer
         Ok(ComputeOffer {
-            system,
             system_id,
+            system,
             proof_offer,
             signature,
         })

--- a/crates/taralli-primitives/src/env.rs
+++ b/crates/taralli-primitives/src/env.rs
@@ -8,6 +8,7 @@ pub enum Environment {
 }
 
 impl Environment {
+    #[must_use]
     pub fn from_env_var() -> Self {
         match env::var("ENV") {
             Ok(val) => match val.to_lowercase().as_str() {
@@ -20,6 +21,7 @@ impl Environment {
     }
 
     /// Converts the `Environment` enum to a string for debugging or display purposes.
+    #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
             Environment::Development => "development",

--- a/crates/taralli-primitives/src/intents/mod.rs
+++ b/crates/taralli-primitives/src/intents/mod.rs
@@ -1,4 +1,4 @@
-//! This module contains the ComputeIntent Implementations used by the protocol.
+//! This module contains the `ComputeIntent` Implementations used by the protocol.
 
 use crate::systems::{System, SystemId};
 use alloy::primitives::{Address, FixedBytes, PrimitiveSignature, U256};

--- a/crates/taralli-primitives/src/systems/mod.rs
+++ b/crates/taralli-primitives/src/systems/mod.rs
@@ -88,25 +88,25 @@ macro_rules! systems {
         }
 
         impl SystemId {
-            pub fn as_str(&self) -> &'static str {
+            #[must_use] pub fn as_str(&self) -> &'static str {
                 match self {
                     $(Self::$variant => $str),*
                 }
             }
-            pub const fn all() -> [SystemId; {count!($($variant),*)}] {
+            #[must_use] pub const fn all() -> [SystemId; {count!($($variant),*)}] {
                 use SystemId::*;
                 [
                     $($variant),*
                 ]
             }
 
-            pub fn as_bit(&self) -> SystemIdMask {
+            #[must_use] pub fn as_bit(&self) -> SystemIdMask {
                 match self {
                     $(Self::$variant => $bit),*
                 }
             }
 
-            pub fn from_bit(bit: SystemIdMask) -> Option<Self> {
+            #[must_use] pub fn from_bit(bit: SystemIdMask) -> Option<Self> {
                 match bit {
                     $($bit => Some(Self::$variant),)*
                     _ => None,

--- a/crates/taralli-primitives/src/systems/risc0.rs
+++ b/crates/taralli-primitives/src/systems/risc0.rs
@@ -56,6 +56,7 @@ pub struct Risc0VerifierConstraints {
 
 impl Risc0VerifierConstraints {
     /// Create network-specific constraints
+    #[must_use]
     pub fn for_network(network: Network) -> Self {
         match network {
             Network::Sepolia => Self::sepolia(),
@@ -64,6 +65,7 @@ impl Risc0VerifierConstraints {
     }
 
     /// Sepolia network constraints
+    #[must_use]
     pub fn sepolia() -> Self {
         Self {
             verifier: Some(address!("AC292cF957Dd5BA174cdA13b05C16aFC71700327")),

--- a/crates/taralli-primitives/src/systems/sp1.rs
+++ b/crates/taralli-primitives/src/systems/sp1.rs
@@ -79,6 +79,7 @@ pub struct Sp1VerifierConstraints {
 
 impl Sp1VerifierConstraints {
     /// Create network-specific constraints
+    #[must_use]
     pub fn for_network(network: Network) -> Self {
         match network {
             Network::Sepolia => Self::sepolia(),
@@ -87,6 +88,7 @@ impl Sp1VerifierConstraints {
     }
 
     /// Sepolia network constraints
+    #[must_use]
     pub fn sepolia() -> Self {
         Self {
             verifier: Some(address!("AC292cF957Dd5BA174cdA13b05C16aFC71700327")),

--- a/crates/taralli-primitives/src/utils.rs
+++ b/crates/taralli-primitives/src/utils.rs
@@ -15,6 +15,7 @@ lazy_static! {
         keccak256(TOKEN_PERMISSIONS_TYPE_STRING.as_bytes());
 }
 
+#[must_use]
 pub fn hash_typed_data(domain_separator: B256, data_hash: B256) -> B256 {
     let final_hash_preimage = [
         "\x19\x01".abi_encode_packed(),

--- a/crates/taralli-primitives/src/validation/mod.rs
+++ b/crates/taralli-primitives/src/validation/mod.rs
@@ -91,9 +91,10 @@ pub fn validate_system<I: ComputeIntent>(intent: &I, supported_systems: &[System
     }
 
     // Validate the proving system specific parameters
-    intent.system().validate_inputs().map_err(|e| {
-        PrimitivesError::ValidationError(format!("invalid system parameters: {}", e))
-    })?;
+    intent
+        .system()
+        .validate_inputs()
+        .map_err(|e| PrimitivesError::ValidationError(format!("invalid system parameters: {e}")))?;
 
     Ok(())
 }
@@ -115,7 +116,7 @@ pub fn validate_time_constraints(
     min_proving_time: u32,
     max_start_delay: u32,
 ) -> Result<()> {
-    if latest_timestamp < start_auction_timestamp.saturating_sub(max_start_delay as u64)
+    if latest_timestamp < start_auction_timestamp.saturating_sub(u64::from(max_start_delay))
         || latest_timestamp >= end_auction_timestamp
     {
         return Err(PrimitivesError::ValidationError("invalid timestamp".into()));

--- a/crates/taralli-primitives/src/validation/offer.rs
+++ b/crates/taralli-primitives/src/validation/offer.rs
@@ -15,7 +15,7 @@ use crate::{
     PrimitivesError,
 };
 
-/// Verifier constraints specific to ProofOffer proof commitments within ComputeOffer intents
+/// Verifier constraints specific to `ProofOffer` proof commitments within `ComputeOffer` intents
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct OfferVerifierConstraints {
     pub verifier: Option<Address>,
@@ -71,6 +71,7 @@ pub struct ComputeOfferValidator {
 }
 
 impl ComputeOfferValidator {
+    #[must_use]
     pub fn new(
         validation_config: OfferValidationConfig,
         verifier_constraints: OfferVerifierConstraints,
@@ -99,7 +100,7 @@ impl<S: System> IntentValidator<ComputeOffer<S>> for ComputeOfferValidator {
     }
 }
 
-/// ComputeOffer specific validation
+/// `ComputeOffer` specific validation
 pub fn validate_offer<S: System>(
     offer: &ComputeOffer<S>,
     config: &OfferValidationConfig,
@@ -141,7 +142,7 @@ pub fn validate_offer_verifier_details(
     // Decode and validate verifier details structure from the intent
     let verifier_details = ProofOfferVerifierDetails::abi_decode(&proof_offer.extraData, true)
         .map_err(|e| {
-            PrimitivesError::ValidationError(format!("failed to decode VerifierDetails: {}", e))
+            PrimitivesError::ValidationError(format!("failed to decode VerifierDetails: {e}"))
         })?;
 
     // Check each constraint only if it's set
@@ -197,15 +198,15 @@ pub fn validate_offer_signature(
     // ec recover signing public key
     let computed_verifying_key = signature
         .recover_from_prehash(&computed_digest)
-        .map_err(|e| PrimitivesError::ValidationError(format!("ec recover failed: {}", e)))?;
+        .map_err(|e| PrimitivesError::ValidationError(format!("ec recover failed: {e}")))?;
     let computed_signer = Address::from_public_key(&computed_verifying_key);
 
     // check signature validity
-    if computed_signer != proof_offer.signer {
+    if computed_signer == proof_offer.signer {
+        Ok(())
+    } else {
         Err(PrimitivesError::ValidationError(
             "signature invalid: computed signer != request.signer".to_string(),
         ))
-    } else {
-        Ok(())
     }
 }

--- a/crates/taralli-primitives/src/validation/registry.rs
+++ b/crates/taralli-primitives/src/validation/registry.rs
@@ -44,7 +44,7 @@ pub trait ValidatorRegistry {
     ) -> Result<()>;
 }
 
-/// Concrete implementation of ValidatorRegistry
+/// Concrete implementation of `ValidatorRegistry`
 pub struct StandardValidatorRegistry<I, C, V>
 where
     I: ComputeIntent,

--- a/crates/taralli-primitives/src/validation/request.rs
+++ b/crates/taralli-primitives/src/validation/request.rs
@@ -16,7 +16,7 @@ use super::{
     BaseValidationConfig, CommonValidationConfig, CommonVerifierConstraints, IntentValidator,
 };
 
-/// Verifier constraints specific to ProofRequest proof commitments withing ComputeRequest intents
+/// Verifier constraints specific to `ProofRequest` proof commitments withing `ComputeRequest` intents
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RequestVerifierConstraints {
     pub verifier: Option<Address>,
@@ -75,6 +75,7 @@ pub struct ComputeRequestValidator {
 }
 
 impl ComputeRequestValidator {
+    #[must_use]
     pub fn new(
         validation_config: RequestValidationConfig,
         verifier_constraints: RequestVerifierConstraints,
@@ -103,7 +104,7 @@ impl<S: System> IntentValidator<ComputeRequest<S>> for ComputeRequestValidator {
     }
 }
 
-/// ComputeRequest specific validation
+/// `ComputeRequest` specific validation
 pub fn validate_request<S: System>(
     request: &ComputeRequest<S>,
     validation_config: &RequestValidationConfig,
@@ -143,7 +144,7 @@ pub fn validate_request_verifier_details(
     // Decode and validate verifier details structure from the intent
     let verifier_details = ProofRequestVerifierDetails::abi_decode(&proof_request.extraData, true)
         .map_err(|e| {
-            PrimitivesError::ValidationError(format!("failed to decode VerifierDetails: {}", e))
+            PrimitivesError::ValidationError(format!("failed to decode VerifierDetails: {e}"))
         })?;
 
     // Check each constraint only if it's set
@@ -231,15 +232,15 @@ pub fn validate_request_signature(
     // ec recover signing public key
     let computed_verifying_key = signature
         .recover_from_prehash(&computed_digest)
-        .map_err(|e| PrimitivesError::ValidationError(format!("ec recover failed: {}", e)))?;
+        .map_err(|e| PrimitivesError::ValidationError(format!("ec recover failed: {e}")))?;
     let computed_signer = Address::from_public_key(&computed_verifying_key);
 
     // check signature validity
-    if computed_signer != proof_request.signer {
+    if computed_signer == proof_request.signer {
+        Ok(())
+    } else {
         Err(PrimitivesError::ValidationError(
             "signature invalid: computed signer != request.signer".to_string(),
         ))
-    } else {
-        Ok(())
     }
 }

--- a/crates/taralli-server/docker-compose.yml
+++ b/crates/taralli-server/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "8080:8080"
 
   postgres:
-    container_name: taralli-auth
+    container_name: taralli-auth-db
     image: postgres:17
     environment:
       POSTGRES_URL: localhost

--- a/crates/taralli-server/src/config.rs
+++ b/crates/taralli-server/src/config.rs
@@ -75,6 +75,7 @@ impl Config {
             .map_err(|_| ConfigError::LogLevelParseError(self.log_level.clone()))
     }
 
+    #[must_use]
     pub fn get_request_validation_config(&self) -> RequestValidationConfig {
         RequestValidationConfig {
             base: self.base_validation_config.clone(),
@@ -82,6 +83,7 @@ impl Config {
         }
     }
 
+    #[must_use]
     pub fn get_offer_validation_config(&self) -> OfferValidationConfig {
         OfferValidationConfig {
             base: self.base_validation_config.clone(),
@@ -96,6 +98,7 @@ impl Config {
         }
     }
 
+    #[must_use]
     pub fn get_validation_configs(&self) -> ServerValidationConfigs {
         ServerValidationConfigs {
             request: self.get_request_validation_config(),

--- a/crates/taralli-server/src/error.rs
+++ b/crates/taralli-server/src/error.rs
@@ -42,7 +42,7 @@ impl IntoResponse for ServerError {
         let (status, error_message) = match &self {
             ServerError::ValidationTimeout(secs) => (
                 StatusCode::REQUEST_TIMEOUT,
-                format!("Validation timed out after {} seconds", secs),
+                format!("Validation timed out after {secs} seconds"),
             ),
             ServerError::NoProvidersAvailable() => (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -51,7 +51,7 @@ impl IntoResponse for ServerError {
             ServerError::ValidationError(s) => (StatusCode::BAD_REQUEST, s.to_owned()),
             ServerError::BroadcastError(s) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Broadcast failed: {}", s),
+                format!("Broadcast failed: {s}"),
             ),
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/taralli-server/src/extracted_intents.rs
+++ b/crates/taralli-server/src/extracted_intents.rs
@@ -57,7 +57,7 @@ where
                 Some(s) => {
                     return Err((
                         StatusCode::BAD_REQUEST,
-                        format!("Field not recognized on submission {}", s),
+                        format!("Field not recognized on submission {s}"),
                     ));
                 }
                 None => {
@@ -133,7 +133,7 @@ where
                 Some(s) => {
                     return Err((
                         StatusCode::BAD_REQUEST,
-                        format!("Field not recognized on submission {}", s),
+                        format!("Field not recognized on submission {s}"),
                     ));
                 }
                 None => {

--- a/crates/taralli-server/src/postgres.rs
+++ b/crates/taralli-server/src/postgres.rs
@@ -44,7 +44,7 @@ pub const GET_INTENTS_BY_ID: &str = "
     AND intents.expired_at IS NULL;
 ";
 
-/// Postgres database used to store compute intents (currently ComputeOffers only)
+/// Postgres database used to store compute intents (currently `ComputeOffers` only)
 #[derive(Clone)]
 pub struct Db {
     pub pool: Pool,
@@ -102,7 +102,7 @@ impl Db {
         Ok(())
     }
 
-    /// Store a submitted ComputeOffer within the database
+    /// Store a submitted `ComputeOffer` within the database
     pub async fn store_offer(
         &self,
         compressed_offer: &ComputeOfferCompressed,

--- a/crates/taralli-server/src/routes/query.rs
+++ b/crates/taralli-server/src/routes/query.rs
@@ -29,8 +29,7 @@ pub async fn get_active_intents_by_id_handler<T: Transport + Clone, P: Provider<
         Err(e) => {
             tracing::error!("Database error when querying intents: {}", e);
             return Err(ServerError::DatabaseError(format!(
-                "Failed to query intents: {}",
-                e
+                "Failed to query intents: {e}"
             )));
         }
     };

--- a/crates/taralli-server/src/routes/submit.rs
+++ b/crates/taralli-server/src/routes/submit.rs
@@ -12,7 +12,7 @@ use crate::state::request::RequestState;
 use crate::subscription_manager::BroadcastedMessage;
 use crate::validation::{validate_partial_offer, validate_partial_request};
 
-/// submit ComputeRequest
+/// submit `ComputeRequest`
 pub async fn submit_request_handler<T: Transport + Clone, P: Provider<T> + Clone>(
     State(state): State<RequestState<T, P>>,
     ExtractedRequest {
@@ -51,7 +51,7 @@ pub async fn submit_request_handler<T: Transport + Clone, P: Provider<T> + Clone
     }
 }
 
-/// submit ComputeOffer
+/// submit `ComputeOffer`
 pub async fn submit_offer_handler<T: Transport + Clone, P: Provider<T> + Clone>(
     State(state): State<OfferState<T, P>>,
     ExtractedOffer {

--- a/crates/taralli-server/src/routes/subscribe.rs
+++ b/crates/taralli-server/src/routes/subscribe.rs
@@ -110,7 +110,7 @@ async fn websocket_subscribe<T: Transport + Clone, P: Provider<T> + Clone>(
                         tracing::info!("Client sent Close: {:?}", message.take());
                         break;
                     }
-                    Some(Ok(Message::Ping(_)) | Ok(Message::Pong(_))) => {
+                    Some(Ok(Message::Ping(_) | Message::Pong(_))) => {
                         // Received a ping or pong, no need to do anything
                     }
                     Some(Err(e)) => {

--- a/crates/taralli-server/src/state/offer.rs
+++ b/crates/taralli-server/src/state/offer.rs
@@ -4,7 +4,7 @@ use crate::postgres::Db;
 
 use super::BaseState;
 
-/// ComputeOffer specific state
+/// `ComputeOffer` specific state
 #[derive(Clone)]
 pub struct OfferState<T, P> {
     pub base: BaseState<T, P>,

--- a/crates/taralli-server/src/state/request.rs
+++ b/crates/taralli-server/src/state/request.rs
@@ -6,7 +6,7 @@ use crate::subscription_manager::SubscriptionManager;
 
 use super::BaseState;
 
-/// ComputeRequest specific state
+/// `ComputeRequest` specific state
 #[derive(Clone)]
 pub struct RequestState<T, P> {
     pub base: BaseState<T, P>,

--- a/crates/taralli-server/src/subscription_manager.rs
+++ b/crates/taralli-server/src/subscription_manager.rs
@@ -6,7 +6,7 @@ use crate::error::{Result, ServerError};
 #[derive(Clone)]
 /// A wrapper type for the message that is broadcasted to all subscribers.
 /// content: The serialized compute request, with system information being compressed.
-/// subscribed_to: The system id that the compute request is related to. See `systems` macro in primitives.
+/// `subscribed_to`: The system id that the compute request is related to. See `systems` macro in primitives.
 pub struct BroadcastedMessage {
     pub content: Vec<u8>,
     pub subscribed_to: SystemIdMask,
@@ -25,15 +25,18 @@ impl<M> SubscriptionManager<M>
 where
     M: Clone,
 {
+    #[must_use]
     pub fn new(capacity: usize) -> Self {
         let (sender, _) = broadcast::channel(capacity);
         Self { sender }
     }
 
+    #[must_use]
     pub fn add_subscription(&self) -> Receiver<M> {
         self.sender.subscribe()
     }
 
+    #[must_use]
     pub fn active_subscriptions(&self) -> usize {
         self.sender.receiver_count()
     }

--- a/crates/taralli-server/tests/server_tests.rs
+++ b/crates/taralli-server/tests/server_tests.rs
@@ -52,7 +52,7 @@ async fn test_broadcast_single(
             "message": "compute request broadcast to providers",
             "broadcast_receivers": 1
         })
-    )
+    );
 }
 
 #[tokio::test]
@@ -81,7 +81,7 @@ async fn test_broadcast_multiple(requester_fixture: SubmitApiClient) {
             "message": "compute request broadcast to providers",
             "broadcast_receivers": 2
         })
-    )
+    );
 }
 
 #[tokio::test]
@@ -203,7 +203,7 @@ async fn test_broadcast_with_specific_proving_systems(requester_fixture: SubmitA
         let message = subscription_arkworks_risc0
             .next()
             .now_or_never()
-            .unwrap_or_else(|| panic!("Missing request {} from stream", i))
+            .unwrap_or_else(|| panic!("Missing request {i} from stream"))
             .expect("No request received")
             .unwrap();
         if i == 0 {

--- a/crates/taralli-worker/src/arkworks.rs
+++ b/crates/taralli-worker/src/arkworks.rs
@@ -32,6 +32,7 @@ type ProofValues = (Vec<DynSolValue>, Vec<Vec<DynSolValue>>, Vec<DynSolValue>);
 
 /// TODO: make generic over any circuit
 impl ArkworksWorker {
+    #[must_use]
     pub fn new() -> Self {
         Self
     }

--- a/crates/taralli-worker/src/risc0/local.rs
+++ b/crates/taralli-worker/src/risc0/local.rs
@@ -9,6 +9,7 @@ pub struct Risc0LocalProver {
 }
 
 impl Risc0LocalProver {
+    #[must_use]
     pub fn new(proving_options: ProverOpts) -> Self {
         Self { proving_options }
     }

--- a/crates/taralli-worker/src/sp1/local.rs
+++ b/crates/taralli-worker/src/sp1/local.rs
@@ -18,6 +18,7 @@ pub struct Sp1LocalProver {
 }
 
 impl Sp1LocalProver {
+    #[must_use]
     pub fn new(use_cuda: bool, proof_mode: SP1ProofMode) -> Self {
         let prover = if use_cuda {
             Sp1LocalProverType::Cuda(ProverClient::builder().cuda().build())

--- a/crates/taralli-worker/src/sp1/remote.rs
+++ b/crates/taralli-worker/src/sp1/remote.rs
@@ -17,6 +17,7 @@ pub struct Sp1RemoteProver {
 }
 
 impl Sp1RemoteProver {
+    #[must_use]
     pub fn new(
         private_key: &str,
         rpc_url: &str,


### PR DESCRIPTION
I reckon we should change the ci clippy check from `clippy::perf` to `clippy::pedantic` too (or maybe add both), but there's quite a few warnings generated as of now and it'd be quite a bit of work to go through all of it. Let clippy auto apply the easy ones here.